### PR TITLE
Filter credentials by issuer DID, circut urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0] - 2023-10-20
 ### Changed
-- `@rarimo/rarime`: add `issuerDID` to filter credentials by issuer
+- `@rarimo/rarime`:
+  - add `issuerDID` to filter credentials by issuer
+  - update circuit urls
 
 
 ## [0.6.0] - 2023-10-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2023-10-20
+### Changed
+- `@rarimo/rarime`: add `issuerDID` to filter credentials by issuer
+
+
 ## [0.6.0] - 2023-10-19
 ### Changed
 - `@rarimo/rarime`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.0] - 2023-10-20
+## [0.7.0] - 2023-10-21
 ### Changed
 - `@rarimo/rarime`:
-  - add `issuerDID` to filter credentials by issuer
   - update circuit urls
+
+### Fixed
+- `@rarimo/rarime`:
+  - add `issuerDID` to filter credentials by issuer
 
 
 ## [0.6.0] - 2023-10-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `@rarimo/rarime`:
-  - add `issuerDID` to filter credentials by issuer
+  - add `issuerDid` to filter credentials by issuer
 
 
 ## [0.6.0] - 2023-10-19

--- a/packages/connector/package.json
+++ b/packages/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rarimo/rarime-connector",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Facilitates interaction between a DApp and RariMe MetaMask snap",
   "repository": {
     "type": "git",

--- a/packages/connector/src/types.ts
+++ b/packages/connector/src/types.ts
@@ -94,7 +94,7 @@ export type ProofQuery = {
 export type CreateProofRequestParams = {
   id?: number;
   accountAddress?: string; // Metamask user address for onchain proofs
-  issuerDID: string;
+  issuerDid: string;
   circuitId:
     | 'credentialAtomicQueryMTPV2'
     | 'credentialAtomicQueryMTPV2OnChain'

--- a/packages/connector/src/types.ts
+++ b/packages/connector/src/types.ts
@@ -94,6 +94,7 @@ export type ProofQuery = {
 export type CreateProofRequestParams = {
   id?: number;
   accountAddress?: string; // Metamask user address for onchain proofs
+  issuerDID: string;
   circuitId:
     | 'credentialAtomicQueryMTPV2'
     | 'credentialAtomicQueryMTPV2OnChain'

--- a/packages/connector/src/version.json
+++ b/packages/connector/src/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "0.6.x"
+  "version": "0.7.x"
 }

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "license": "(MIT-0 OR Apache-2.0)",
   "scripts": {

--- a/packages/snap/README.md
+++ b/packages/snap/README.md
@@ -92,6 +92,7 @@ await window.ethereum.request({
 where:
 - **circuitId**: type of proof
 - **accountAddress**(optional): Metamask user address for onchain proofs
+- **issuerDid**: did of the issuer trusted by the verifier
 - **challenge**(optional): text that will be signed
 - **query**
 	- **allowedIssuers**: types of issuers allowed

--- a/packages/snap/README.md
+++ b/packages/snap/README.md
@@ -72,6 +72,7 @@ await window.ethereum.request({
       method: 'create_proof',
       params: {
         circuitId: 'credentialAtomicQuerySigV2OnChain',
+        issuerDid: 'did:iden3:[...]',
         accountAddress: '0x......',
         challenge: '1251760352881625298994789945427452069454957821390', // BigInt string
         query: {

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rarimo/rarime",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "RariMe is a MetaMask Snap that safely holds any of your credentials and allows you to prove your identity without revealing any personal data. Powered by Rarimo Protocol and  Zero-Knowledge Proof technology.",
   "repository": {
     "type": "git",
@@ -45,7 +45,7 @@
     "@metamask/snaps-jest": "0.35.2-flask.1",
     "@metamask/snaps-types": "0.32.2",
     "@metamask/snaps-ui": "0.32.2",
-    "@rarimo/rarime-connector": "0.6.0",
+    "@rarimo/rarime-connector": "0.7.0",
     "buffer": "6.0.3",
     "ethers": "5.7.2",
     "intl": "1.2.5",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/rarimo/rarime.git"
   },
   "source": {
-    "shasum": "qwGl3IBgzNUUd5bsWem1tyy3cSNIBqyFNtTV+29xsdY=",
+    "shasum": "zKTZH0PaVOy8rRYT0dhcJNt9+ZU17fidtNsq9whD/PQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Securely store and manage all of your identity credentials. Use them across chains with ZK-protected privacy guarantees.",
   "proposedName": "RariMe",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/rarimo/rarime.git"
   },
   "source": {
-    "shasum": "zKTZH0PaVOy8rRYT0dhcJNt9+ZU17fidtNsq9whD/PQ=",
+    "shasum": "wj2tpwdOEiIUfwWsiXRc2yfXkc8v9hPXgKUdA4OmbXw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/rarimo/rarime.git"
   },
   "source": {
-    "shasum": "wj2tpwdOEiIUfwWsiXRc2yfXkc8v9hPXgKUdA4OmbXw=",
+    "shasum": "bCrZQRTvgI6wb13m/AWOTkWVz0fjApfgp6xgpxw8jxU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/rarimo/rarime.git"
   },
   "source": {
-    "shasum": "bCrZQRTvgI6wb13m/AWOTkWVz0fjApfgp6xgpxw8jxU=",
+    "shasum": "+/w3xenuezpRSfg7GygzstbeE5sYqD/VTdZ4VmGou/k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/config.ts
+++ b/packages/snap/src/config.ts
@@ -18,25 +18,25 @@ export const config = {
   },
 
   CIRCUIT_AUTH_WASM_URL:
-    'https://ipfs.tokend.io/ipfs/ipfs/QmYd41GHrKQLqbk96zHbmHU5rGVcxwmAgBpRqLCGLK7LQu',
+    'https://ipfs.rarimo.com/ipfs/QmYd41GHrKQLqbk96zHbmHU5rGVcxwmAgBpRqLCGLK7LQu',
   CIRCUIT_AUTH_FINAL_KEY_URL:
-    'https://ipfs.tokend.io/ipfs/ipfs/QmWKor7i9r2zbM6oqSdgPUCvgyYESH39qXk1f5tbdeaAg7',
+    'https://ipfs.rarimo.com/ipfs/QmWKor7i9r2zbM6oqSdgPUCvgyYESH39qXk1f5tbdeaAg7',
   CIRCUIT_SIG_V2_ON_CHAIN_WASM_URL:
-    'https://ipfs.tokend.io/ipfs/ipfs/QmS4vURQ1c8tgALSokdTYVqx5E9FmASbu964W3JevnM3B4',
+    'https://ipfs.rarimo.com/ipfs/QmS4vURQ1c8tgALSokdTYVqx5E9FmASbu964W3JevnM3B4',
   CIRCUIT_SIG_V2_ON_CHAIN_FINAL_KEY_URL:
-    'https://ipfs.tokend.io/ipfs/ipfs/QmT45Y62hfZnADq6VvKGjNR8foNb2KjcyG4AStRRAN9iHm',
+    'https://ipfs.rarimo.com/ipfs/QmT45Y62hfZnADq6VvKGjNR8foNb2KjcyG4AStRRAN9iHm',
   CIRCUIT_SIG_V2_WASM_URL:
-    'https://ipfs.tokend.io/ipfs/ipfs/QmYB5QLvH5ihiedxvzkG3XPQngjxcS8wc1xCAoKnGS5GfC',
+    'https://ipfs.rarimo.com/ipfs/QmYB5QLvH5ihiedxvzkG3XPQngjxcS8wc1xCAoKnGS5GfC',
   CIRCUIT_SIG_V2_FINAL_KEY_URL:
-    'https://ipfs.tokend.io/ipfs/ipfs/QmeXxRXxYGCwa48ANikH5Knzi9cgkmhumPbMtjTKNYkThL',
+    'https://ipfs.rarimo.com/ipfs/QmeXxRXxYGCwa48ANikH5Knzi9cgkmhumPbMtjTKNYkThL',
   CIRCUIT_MTP_V2_WASM_URL:
-    'https://ipfs.tokend.io/ipfs/ipfs/QmRqGgnN6Qy4LuPxQKH2wrADNe4aJb8wYJhS1ky9zbLS8t',
+    'https://ipfs.rarimo.com/ipfs/QmRqGgnN6Qy4LuPxQKH2wrADNe4aJb8wYJhS1ky9zbLS8t',
   CIRCUIT_MTP_V2_FINAL_KEY_URL:
-    'https://ipfs.tokend.io/ipfs/ipfs/QmcLyDLPWJpyEWeR9KkWQuGHAqifnwpDAWBX1R6a7g6F6a',
+    'https://ipfs.rarimo.com/ipfs/QmcLyDLPWJpyEWeR9KkWQuGHAqifnwpDAWBX1R6a7g6F6a',
   CIRCUIT_MTP_V2_ON_CHAIN_WASM_URL:
-    'https://ipfs.tokend.io/ipfs/ipfs/QmPtPiFgZigau2VNpSCoagNj36ZpuuATRNvyNPAvvUgvq6',
+    'https://ipfs.rarimo.com/ipfs/QmPtPiFgZigau2VNpSCoagNj36ZpuuATRNvyNPAvvUgvq6',
   CIRCUIT_MTP_V2_ON_CHAIN_FINAL_KEY_URL:
-    'https://ipfs.tokend.io/ipfs/ipfs/QmU8fC3xwjMcmnsB88SrdKRZpskhxUwBRnaLMa1AcN9ERj',
+    'https://ipfs.rarimo.com/ipfs/QmU8fC3xwjMcmnsB88SrdKRZpskhxUwBRnaLMa1AcN9ERj',
 };
 
 enum CHAINS {

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -142,7 +142,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
 
       const params = (request.params as any) as CreateProofRequestParams;
 
-      const { issuerDID, ...createProofRequest } = params;
+      const { issuerDid, ...createProofRequest } = params;
 
       isValidCreateProofRequest(createProofRequest);
 
@@ -163,7 +163,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
       ).filter(
         (cred) =>
           cred.credentialSubject.id === identityStorage.did &&
-          cred.issuer === issuerDID,
+          cred.issuer === issuerDid,
       );
 
       if (!credentials.length) {

--- a/packages/snap/src/types/proof-types.ts
+++ b/packages/snap/src/types/proof-types.ts
@@ -23,7 +23,7 @@ export type CreateProofRequest = {
 };
 
 export type CreateProofRequestParams = {
-  issuerDID: string;
+  issuerDid: string;
 } & CreateProofRequest;
 
 export type State = {

--- a/packages/snap/src/types/proof-types.ts
+++ b/packages/snap/src/types/proof-types.ts
@@ -22,6 +22,10 @@ export type CreateProofRequest = {
   query: ProofQuery;
 };
 
+export type CreateProofRequestParams = {
+  issuerDID: string;
+} & CreateProofRequest;
+
 export type State = {
   txId?: string;
   blockTimestamp?: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6271,7 +6271,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rarimo/rarime-connector@0.6.0, @rarimo/rarime-connector@workspace:^, @rarimo/rarime-connector@workspace:packages/connector":
+"@rarimo/rarime-connector@0.7.0, @rarimo/rarime-connector@workspace:^, @rarimo/rarime-connector@workspace:packages/connector":
   version: 0.0.0-use.local
   resolution: "@rarimo/rarime-connector@workspace:packages/connector"
   dependencies:
@@ -6305,7 +6305,7 @@ __metadata:
     "@metamask/snaps-jest": 0.35.2-flask.1
     "@metamask/snaps-types": 0.32.2
     "@metamask/snaps-ui": 0.32.2
-    "@rarimo/rarime-connector": 0.6.0
+    "@rarimo/rarime-connector": 0.7.0
     "@typechain/ethers-v5": 11.1.1
     "@types/intl": 1.2.0
     "@types/uuid": 9.0.2


### PR DESCRIPTION
- Explicitly filter credentials by `issuerDid` when generating ZKPs;
- Use new circuit ipfs urls to improve performance;